### PR TITLE
Refactor team initialize to be consistent

### DIFF
--- a/lib/team.rb
+++ b/lib/team.rb
@@ -1,12 +1,12 @@
 class Team
   attr_reader :team_id, :franchise_id, :teamName, :abbreviation, :stadium, :link
 
-  def initialize(team_id,franchiseid,teamName,abbreviation,stadium,link)
-    @team_id = team_id
-    @franchise_id = franchiseid
-    @teamName = teamName
-    @abbreviation = abbreviation
-    @stadium = stadium
-    @link = link
+  def initialize(source)
+    @team_id = source[:team_id]
+    @franchise_id = source[:franchiseId]
+    @teamName = source[:teamName]
+    @abbreviation = source[:abbreviation]
+    @stadium = source[:Stadium]
+    @link = source[:link]
   end
 end

--- a/lib/teams_factory.rb
+++ b/lib/teams_factory.rb
@@ -15,7 +15,7 @@ class Teams_factory
 
     CSV.foreach(file_path, headers:true, header_converters: custom_header_converter) do |row|
 
-      team = Team.new(row[:team_id], row[:franchiseId], row[:teamName], row[:abbreviation], row[:Stadium], row[:link])
+      team = Team.new(row)
       @teams << team
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,5 @@ require 'csv'
 
 require './lib/game.rb'
 require './lib/game_factory.rb'
+require './lib/team.rb'
+require './lib/teams_factory.rb'

--- a/spec/team_spec.rb
+++ b/spec/team_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 RSpec.describe 'team' do
   before(:each) do
-    @team1 = Team.new('1','2','The Capybaras', 'CAP', "Wally\'s World", 'http:\\google.com')
+    row = {team_id: '1',franchiseId:'2',teamName: 'The Capybaras',abbreviation: 'CAP',Stadium: "Wally\'s World" ,link: 'http:\\google.com'}
+    @team1 = Team.new(row)
   end
 
   describe '#initialize' do
     it 'exists' do
+      # binding.pry
       expect(@team1).to be_an_instance_of(Team)
       expect(@team1.team_id).to eq('1')
       expect(@team1.franchise_id).to eq('2')
@@ -16,6 +18,4 @@ RSpec.describe 'team' do
       expect(@team1.link).to eq("http:\\google.com")
     end
   end
-
-
 end

--- a/spec/team_spec.rb
+++ b/spec/team_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'team' do
 
   describe '#initialize' do
     it 'exists' do
-      # binding.pry
       expect(@team1).to be_an_instance_of(Team)
       expect(@team1.team_id).to eq('1')
       expect(@team1.franchise_id).to eq('2')


### PR DESCRIPTION
Refactor to use a row object rather than individual variables in team initialize method.